### PR TITLE
Fixes path separator in song name issue

### DIFF
--- a/game/Online_library_Panel.gd
+++ b/game/Online_library_Panel.gd
@@ -153,20 +153,23 @@ func _on_HTTPRequest_download_completed(result, response_code, headers, body):
 			vr.log_info(str(error))
 			has_error = true
 		
+		# sanitize path separators from song directory name
+		var song_dir_name = downloading[0][0].replace('/','')
+		
 		var file = File.new()
-		file.open(game.menu.bspath+"temp/%s.zip"%downloading[0][0],File.WRITE)
+		file.open(game.menu.bspath+"temp/%s.zip"%song_dir_name,File.WRITE)
 		file.store_buffer(body)
 		file.close()
 		
-		error = dir.make_dir_recursive(game.menu.bspath+("Songs/%s"%downloading[0][0]))
+		error = dir.make_dir_recursive(game.menu.bspath+("Songs/%s"%song_dir_name))
 		if error != 0: 
 			vr.log_info(str(error))
 			has_error = true
 		
 		var Unzip = load('res://addons/gdunzip/unzip.gd').new()
-		error = Unzip.unzip(game.menu.bspath+"temp/%s.zip"%downloading[0][0],game.menu.bspath+("Songs/%s/"%downloading[0][0]))
+		error = Unzip.unzip(game.menu.bspath+"temp/%s.zip"%song_dir_name,game.menu.bspath+("Songs/%s/"%song_dir_name))
 		
-		dir.remove(game.menu.bspath+"temp/%s.zip"%downloading[0][0])
+		dir.remove(game.menu.bspath+"temp/%s.zip"%song_dir_name)
 		
 		downloading.remove(0)
 		


### PR DESCRIPTION
When there was a path separator char '/' in the song name or artist name, it was cause the song downloading logic to fail.
Fixed by sanitizing the song's extraction directory name of all path separators.
I also added some extra error handling and more verbose error logging in that download_completed handler.