### PR TITLE
Fixes map restarting bug

### DIFF
--- a/game/BeepSaber_Game.gd
+++ b/game/BeepSaber_Game.gd
@@ -92,9 +92,6 @@ func restart_map():
 		$Track.remove_child(c);
 		c.queue_free();
 	
-	for w in get_tree().get_nodes_in_group("wall"):
-		w.queue_free()
-
 	$MainMenu_OQ_UI2DCanvas.visible = false;
 	$Settings_canvas.visible = false;
 	$Online_library.visible = false;


### PR DESCRIPTION
Here's a video showing the bug with restarting a map. You can see the notes persist between restart, and also how it doesn't start to spawn note until you reach the playback_position where you initiated the restart.
https://user-images.githubusercontent.com/216870/114287212-39489600-9a33-11eb-9f73-07d663c3fb51.mp4

Here's a video showing the behavior after the fix.
https://user-images.githubusercontent.com/216870/114287253-96444c00-9a33-11eb-92e1-11c25062981e.mp4
