### PR TITLE
Beatsaver API fixes

### DIFF
--- a/game/Online_library_Panel.gd
+++ b/game/Online_library_Panel.gd
@@ -154,6 +154,7 @@ func _on_ItemList_item_selected(index):
 	item_selected = index
 	var selected_data = _get_selected_song()
 	var metadata = selected_data["metadata"]
+	var dur_s = int(metadata["duration"])
 	var version = selected_data["versions"][0]
 	goto_maps_by.text = "Maps by %s" % metadata["levelAuthorName"]
 	goto_maps_by.visible = true
@@ -163,7 +164,7 @@ func _on_ItemList_item_selected(index):
 	var text = """[center]%s By %s[/center]
 
 Map author: %s
-Duration: %s
+Duration: %dm %ds
 Difficulties:%s
 
 [center]Description:[/center]
@@ -171,7 +172,7 @@ Difficulties:%s
 		metadata["songName"],
 		metadata["songAuthorName"],
 		metadata["levelAuthorName"],
-		metadata["duration"],
+		dur_s/60,dur_s%60,
 		difficulties,
 		selected_data["description"],
 	]

--- a/game/Online_library_Panel.gd
+++ b/game/Online_library_Panel.gd
@@ -89,7 +89,7 @@ func update_list(request):
 		"text_search":
 			var search_text = request.search_text
 			$mode.text = search_text
-			httpreq.request("https://beatsaver.com/api/search/text/%s?q=%s" % [page,search_text.percent_encode()])
+			httpreq.request("https://beatsaver.com/api/search/text/%s?q=%s&automapper=true" % [page,search_text.percent_encode()])
 		"uploader":
 			var uploader_id = request.uploader_id
 			$mode.text = "Uploader"
@@ -304,7 +304,7 @@ func _on_gotoMapsBy_pressed():
 	prev_request = {
 		"type" : "uploader",
 		"page" : 0,
-		"uploader_id" : selected_song["uploader"]["_id"]
+		"uploader_id" : selected_song["uploader"]["id"]
 	}
 	update_list(prev_request)
 	

--- a/game/Online_library_Panel.gd
+++ b/game/Online_library_Panel.gd
@@ -93,7 +93,6 @@ func update_list(request):
 		"text_search":
 			var search_text = request.search_text
 			$mode.text = search_text
-			vr.log_info("Requesting page %s" % page)
 			httpreq.request("https://beatsaver.com/api/search/text/%s?q=%s&sortOrder=Relevance&automapper=true" % [page,search_text.percent_encode()])
 		"uploader":
 			var uploader_id = request.uploader_id

--- a/game/Online_library_Panel.gd
+++ b/game/Online_library_Panel.gd
@@ -6,7 +6,9 @@ var current_list = 0
 # not requestable (ie. reached end of the list)
 var prev_page_available = null
 var next_page_available = null
-var list_modes = ["hot","rating","latest","downloads","plays"]
+# Older API used to support more lists. temporarily limiting to ones that still work
+#var list_modes = ["hot","rating","latest","downloads","plays"]
+var list_modes = ["plays"]
 var search_word = ""
 var item_selected = -1
 var downloading = []#[["name","version_info"]]
@@ -28,7 +30,7 @@ var prev_request = {
 	"page" : 0,
 	
 	# type-specific fields when type is "list"
-	"list" : "hot"
+	"list" : "plays"
 	
 	# type-specific fields when type is "text_search"
 	# "search_text" = ""
@@ -41,7 +43,7 @@ export(NodePath) var game;
 export(NodePath) var keyboard;
 
 func enable():
-	update_list({"type":"list","page":0,"list":"hot"})
+	update_list({"type":"list","page":0,"list":"plays"})
 	$ColorRect.visible = false
 
 func _ready():

--- a/game/Online_library_Panel.gd
+++ b/game/Online_library_Panel.gd
@@ -9,7 +9,7 @@ var next_page_available = null
 var list_modes = ["hot","rating","latest","downloads","plays"]
 var search_word = ""
 var item_selected = -1
-var downloading = []#[["name","key"]]
+var downloading = []#[["name","version_info"]]
 onready var httpreq = HTTPRequest.new()
 onready var httpdownload = HTTPRequest.new()
 onready var httpcoverdownload = HTTPRequest.new()
@@ -181,14 +181,14 @@ Difficulties:%s
 func _on_download_button_up():
 	OS.request_permissions()
 	if item_selected == -1: return
-	downloading.insert(downloading.size(),[song_data[item_selected]["name"],song_data[item_selected]["key"]])
+	var version_info = song_data[item_selected]['versions'][0]
+	downloading.insert(downloading.size(),[song_data[item_selected]["name"],version_info])
 	download_next()
-#	$download.disabled = true
 	
 	
 func download_next():
 	if downloading.size() > 0:
-		httpdownload.request("https://beatsaver.com/api/download/key/%s" % downloading[0][1])
+		httpdownload.request(downloading[0][1]['downloadURL'])
 		$Label.text = "Downloading: %s - %d left" % [str(downloading[0][0]),downloading.size()-1]
 		$Label.visible = true
 		

--- a/game/Online_library_Panel.gd
+++ b/game/Online_library_Panel.gd
@@ -152,24 +152,24 @@ func _on_ItemList_item_selected(index):
 	item_selected = index
 	var selected_data = _get_selected_song()
 	var metadata = selected_data["metadata"]
+	var version = selected_data["versions"][0]
 	goto_maps_by.text = "Maps by %s" % metadata["levelAuthorName"]
 	goto_maps_by.visible = true
 	var difficulties = ""
-	for d in metadata["difficulties"].keys():
-		if metadata["difficulties"][d] == true:
-			difficulties += " %s"%d
+	for diff in version['diffs']:
+		difficulties += " %s" % diff['difficulty']
 	var text = """[center]%s By %s[/center]
 
 Map author: %s
 Duration: %s
-difficulties:%s
+Difficulties:%s
 
 [center]Description:[/center]
 %s""" % [
-		selected_data["metadata"]["songName"],
-		selected_data["metadata"]["songAuthorName"],
-		selected_data["metadata"]["levelAuthorName"],
-		selected_data["metadata"]["duration"],
+		metadata["songName"],
+		metadata["songAuthorName"],
+		metadata["levelAuthorName"],
+		metadata["duration"],
 		difficulties,
 		selected_data["description"],
 	]

--- a/game/Online_library_Panel.gd
+++ b/game/Online_library_Panel.gd
@@ -82,6 +82,8 @@ func update_list(request):
 		item_selected = -1
 	httpcoverdownload.cancel_request()
 	httpreq.cancel_request()
+	prev_page_available = page
+	next_page_available = null
 	
 	match request.type:
 		"list":
@@ -91,7 +93,8 @@ func update_list(request):
 		"text_search":
 			var search_text = request.search_text
 			$mode.text = search_text
-			httpreq.request("https://beatsaver.com/api/search/text/%s?q=%s&automapper=true" % [page,search_text.percent_encode()])
+			vr.log_info("Requesting page %s" % page)
+			httpreq.request("https://beatsaver.com/api/search/text/%s?q=%s&sortOrder=Relevance&automapper=true" % [page,search_text.percent_encode()])
 		"uploader":
 			var uploader_id = request.uploader_id
 			$mode.text = "Uploader"
@@ -113,12 +116,7 @@ func _get_selected_song():
 func _on_HTTPRequest_request_completed(result, response_code, headers, body):
 	if result == 0:
 		var json_data = parse_json(body.get_string_from_utf8())
-		prev_page_available = null
-		next_page_available = null
-		if json_data.has("prevPage"):
-			prev_page_available = json_data["prevPage"]
-		if json_data.has("nextPage"):
-			next_page_available = json_data["nextPage"]
+		next_page_available = prev_page_available + 1
 			
 		if json_data.has("docs"):
 			json_data = json_data["docs"]

--- a/game/Online_library_Panel.tscn
+++ b/game/Online_library_Panel.tscn
@@ -64,12 +64,12 @@ border_color = Color( 1, 1, 1, 1 )
 size = 20
 font_data = ExtResource( 1 )
 
-[sub_resource type="DynamicFont" id=13]
+[sub_resource type="DynamicFont" id=11]
 size = 40
 font_data = ExtResource( 1 )
 
-[sub_resource type="Theme" id=14]
-default_font = SubResource( 13 )
+[sub_resource type="Theme" id=12]
+default_font = SubResource( 11 )
 
 [node name="Online_library_Panel" type="Panel"]
 margin_right = 1536.0
@@ -106,7 +106,7 @@ custom_styles/hover = SubResource( 7 )
 custom_styles/pressed = SubResource( 8 )
 custom_styles/disabled = SubResource( 8 )
 custom_styles/normal = SubResource( 9 )
-text = "Hot"
+text = "Plays"
 clip_text = true
 __meta__ = {
 "_edit_use_anchors_": false
@@ -225,7 +225,7 @@ margin_left = 904.0
 margin_top = -672.0
 margin_right = -32.0
 margin_bottom = -120.0
-theme = SubResource( 14 )
+theme = SubResource( 12 )
 bbcode_enabled = true
 bbcode_text = "[center]Select a song to see the details
 


### PR DESCRIPTION
Restores some of the Beatsaver API functionality after site refactor. I wasn't able to get all of the lists queries to work like "hot now", "most downloaded", etc. Seems like some of those queries are now deprecated.
This PR restores:
- basic text search 
- cover art download
- map download url

Not sure how long these updates will be valid because it seems like the site is still "under construction". We'll see!