### PR TITLE
Revert to default saber if selected saber does not exist

### DIFF
--- a/game/settings_Panel.gd
+++ b/game/settings_Panel.gd
@@ -140,7 +140,9 @@ func _on_d_background_toggled(button_pressed,overwrite=true):
 
 func _on_saber_item_selected(index,overwrite=true):
 	for ls in get_tree().get_nodes_in_group("lightsaber"):
-		ls.set_saber(sabers[index][1])
+		var saber_exists = range(sabers.size()).has(index)
+		if saber_exists: ls.set_saber(sabers[index][1])
+		else: ls.set_saber(sabers[0][1])
 	yield(get_tree(),"idle_frame")
 	game.update_saber_colors()
 	_on_saber_tail_toggled(savedata.saber_tail,false)


### PR DESCRIPTION
I noticed while working on a new saber (~~PR coming soon enough~~ Nevermind, bad git operation deleted the branch) that saving in a version of the game that contains a new saber THEN opening a version of the game without the new saber causes the game to try to select a saber that doesn't exist, and an out-of-bounds array access exception is thrown.

This PR adds code that checks if the selected saber exists, and if it doesn't, reverts to default saber.